### PR TITLE
Release the Cloudflare bypass latch on main-frame load errors (closes #9)

### DIFF
--- a/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
+++ b/core/common/src/main/kotlin/eu/kanade/tachiyomi/network/interceptor/CloudflareInterceptor.kt
@@ -2,6 +2,8 @@ package eu.kanade.tachiyomi.network.interceptor
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -119,6 +121,24 @@ class CloudflareInterceptor(
                             // Unlock thread, the challenge wasn't found.
                             latch.countDown()
                         }
+                    }
+                }
+
+                override fun onReceivedError(
+                    view: WebView?,
+                    request: WebResourceRequest?,
+                    error: WebResourceError?,
+                ) {
+                    if (request?.isForMainFrame == true) {
+                        Log.w(
+                            "CloudflareInterceptor",
+                            "Main-frame load failed for ${request.url}: " +
+                                "code=${error?.errorCode} desc=${error?.description}",
+                        )
+                        // The main frame failed to load (DNS, no network, TLS, ...).
+                        // Without releasing the latch, the interceptor would block for
+                        // the full 30-second timeout before giving up.
+                        latch.countDown()
                     }
                 }
             }


### PR DESCRIPTION
Closes #9

### What this does

Adds an `onReceivedError(view, request, error)` override to the inner `WebViewClient` in `CloudflareInterceptor.resolveWithWebView(...)`. The override only acts on main-frame requests. It logs the error code, description and URL via `Log.w` and then calls `latch.countDown()` so the interceptor thread is released immediately. Sub-resource failures fall through to the existing behaviour.

### Why

The interceptor blocks an OkHttp dispatcher thread on a `CountDownLatch` until something resolves the Cloudflare check. The only paths that release the latch today are `onPageFinished` (cookie issued, or no challenge) and `onReceivedHttpError` (response not a Cloudflare error code). If the WebView main-frame load fails for a non-HTTP reason (network, DNS, TLS, captive portal that drops the request, ...) the framework calls `onReceivedError` instead, and neither of the existing handlers fires. The interceptor then waits out the 30-second `awaitFor30Seconds()` timeout before throwing `CloudflareBypassException`. The user sees the source list freeze for half a minute on a flaky network before the error surfaces.

After this change a transport failure releases the latch right away and the interceptor falls through to the usual `chain.proceed(request)`, which surfaces the real OkHttp error to the caller in milliseconds instead of dragging on for 30 seconds.

No behaviour change to the happy path or to existing Cloudflare-challenge detection. The new override never interferes when the load actually completes.
